### PR TITLE
Update Kitchen test suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,5 @@
 driver:
   name: vagrant
-  ssh:
-    username: vagrant
-    password: vagrant
 
 provisioner:
   name: chef_zero

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,5 @@ platforms:
 suites:
   - name: default
     run_list: cop_php::default
-    attributes: {
-      fpm_enabled: "true"
-    }
+    attributes:
+      fpm_enabled: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,12 +5,9 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-7.2
-  - name: ubuntu-14.04
-  - name: ubuntu-16.04
-    driver:
-      box: ubuntu-16.04.1
-      box_url: https://s3.amazonaws.com/copiousdev/vagrant/ubuntu-16.04-xenial.box
+  - name: ubuntu/trusty64
+  - name: ubuntu/xenial64
+  - name: centos/7
 
 suites:
   - name: default


### PR DESCRIPTION
Updates Kitchen to use default "native" Vagrant boxes, removes password auth override (unnecessary with specified boxes) and cleans YAML syntax for attribute.