### PR TITLE
Cleanup xdebug conf file creation

### DIFF
--- a/attributes/ext-xdebug.rb
+++ b/attributes/ext-xdebug.rb
@@ -23,6 +23,7 @@ default['php']['ext']['xdebug']['directives'] = {
 case node['platform_family']
 when 'debian'
     default['php']['ext']['xdebug']['package'] = 'php-xdebug'
+    default['php']['ext']['xdebug']['config_filename'] = "20-xdebug.ini"
 when 'rhel'
     default['php']['ext']['xdebug']['package'] = 'php70u-xdebug'
     default['php']['ext']['xdebug']['config_filename'] = "15-xdebug.ini"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 license             'MIT'
 maintainer          'Copious, Inc.'
 maintainer_email    'engineering@copiousinc.com'
-version             '0.7.1'
+version             '0.7.2'
 source_url          'https://github.com/copious-cookbooks/php'
 issues_url          'https://github.com/copious-cookbooks/php/issues'
 

--- a/recipes/redis.rb
+++ b/recipes/redis.rb
@@ -34,7 +34,7 @@ end
 
 # Enable mod and restart PHPfpm
 execute 'enable_php_redis' do
-    action  :run
+    action  :nothing
     user    'root'
     command 'phpenmod redis'
     only_if 'which phpenmod'

--- a/recipes/xdebug.rb
+++ b/recipes/xdebug.rb
@@ -4,12 +4,14 @@ if node['php']['ext']['xdebug']['enable']
     end
 
     template "#{node['php']['sapi']['fpm']['module_ini_path']}/#{node['php']['ext']['xdebug']['config_filename']}" do
-        source "xdebug.ini.erb"
+        action :create
+        backup false
+        force_unlink true
+        manage_symlink_source false
         group  "root"
         owner  "root"
         mode   0644
-        backup false
-        action :create
+        source "xdebug.ini.erb"
         variables (
             node['php']['ext']['xdebug']['directives']
         )
@@ -19,7 +21,7 @@ if node['php']['ext']['xdebug']['enable']
 
     # Enable mod and restart PHPfpm
     execute 'enable_php_xdebug' do
-        action      :run
+        action      :nothing
         user        'root'
         command     'phpenmod xdebug'
         only_if     'which phpenmod'


### PR DESCRIPTION
Fixes Ubuntu test failing on xdebug configuration file mode, isolates xdebug fpm configuration from other sapis, removes duplicative run statements for enabling php modules.